### PR TITLE
 Set up CI, based on actions-rs recommendations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+on: [push, pull_request]
+
+name: CI
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [beta, stable, windows, macos]
+        include:
+          - build: macos
+            os: macos-latest
+            rust: stable
+          - build: windows
+            os: windows-latest
+            rust: stable
+          - build: beta
+            os: ubuntu-latest
+            rust: beta
+          - build: stable
+            os: ubuntu-latest
+            rust: stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-fail-fast
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings


### PR DESCRIPTION
This PR is similar to one I made for gaffy last week: https://github.com/ekg/gaffy/pull/1, my comment there:

> The [actions-rs](https://github.com/actions-rs/meta) project maintains actions and example workflows for running CI jobs for Rust in GitHub Actions. This is similar to their quickstart, with extra jobs for macOS and Windows.
> I use a similar workflow in [sourmash](https://github.com/dib-lab/sourmash/blob/86d659797394d331f3a1d5e33968b4c8d9b9b423/.github/workflows/rust.yml), with some extra checks ("coverage" and "minimum supported Rust version" can also be useful to set up here).
> 
> I also like the `clippy` job, because it is a very good pair programmer (I always learn a lot of new idioms and better ways to write my code).
> 
> The `fmt` job can be removed, but `cargo fmt` is also pretty useful to run (and have a consistent formatting style for the code).
> 
> While there are no tests yet, this workflow is also set up to run them when they exist.