### PR TITLE
add a small test 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,7 @@ refinery = { git = "https://github.com/jneem/refinery", branch = "master" }
 
 [features]
 default = ["GSL/v2"]
+
+[dev-dependencies]
+assert_cmd = "0.12.0"
+predicates = "1.0.2"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+//use predicates::prelude::*;
+
+#[test]
+fn terminus_collapse() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("terminus")?;
+    cmd.arg("collapse");
+    cmd.args(&["--dirs", "tests/data/???"]);
+
+    cmd.assert().success();
+
+    Ok(())
+}
+
+#[test]
+fn terminus_group() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("terminus")?;
+    cmd.arg("group");
+    cmd.args(&["--dir", "tests/data/???"]);
+
+    cmd.assert().success();
+
+    Ok(())
+}


### PR DESCRIPTION
(merge after #1)

And this one is similar to https://github.com/ekg/gaffy/pull/2, my comment there:

> Adding a small test to serve as example (but it is missing the test data).
> 
> I have some in [decoct](https://github.com/luizirber/decoct/blob/cfd252e9e315257cff68964bce17e615b99b7326/tests/decoct_cmd.rs#L10) doing more checks (searching for strings in the output, copying test data to tempdir, or reading a generated file and checking for results), if you want to take a look.
> 
> `dev-dependencies` are only installed for some commands (`cargo test`, for example), and don't increase the binary size for the final application.