### PR TITLE
Update to 2018 edition and remove extern calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "terminus"
 version = "0.1.0"
-authors = ["<{rob,hirak}@cs.umd.edu>"]
+authors = ["Rob Patro <rob@cs.umd.edu>", "Hirak Sarkar <hirak@cs.umd.edu>"]
+edition = "2018"
 
 [dependencies]
 GSL = "*"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ from the top-level directory of this repository.  This will produce an executabl
 How to use terminus
 -------------------
 
-Terminus has two sub-commands, `group` and `collapse`. For detailed tutorial and usage please visit the [turotial](https://combine-lab.github.io/terminus-tutorial/2020/running-terminus/) or the [documentation] (https://terminus.readthedocs.io/en/latest/)
+Terminus has two sub-commands, `group` and `collapse`. For detailed tutorial and usage please visit the [tutotial](https://combine-lab.github.io/terminus-tutorial/2020/running-terminus/) or the [documentation](https://terminus.readthedocs.io/en/latest/).
 
 Authors
 -------

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,12 @@
-extern crate clap;
-extern crate csv;
-extern crate flate2;
-extern crate indicatif;
-extern crate itertools;
-extern crate log;
-extern crate log4rs;
-extern crate nalgebra as na;
-extern crate ndarray;
-extern crate ndarray_stats;
-extern crate petgraph;
-extern crate rand;
-extern crate rand_core;
-extern crate rand_pcg;
-extern crate serde;
-extern crate serde_json;
-
-extern crate byteorder;
-extern crate rgsl;
-
-extern crate binary_heap_plus;
-extern crate num_format;
-extern crate num_traits;
-extern crate ordered_float;
-extern crate pretty_env_logger;
-extern crate rayon;
-extern crate refinery;
-
 pub mod salmon_types;
 mod util;
+
+use std::collections::HashMap;
+use std::fs::*;
+use std::io::Write;
+use std::io::{self, BufRead, BufReader};
+use std::process;
+
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use ndarray::prelude::*;
 use num_format::{Locale, ToFormattedString};
@@ -35,11 +14,7 @@ use petgraph as pg;
 use petgraph::algo::{connected_components, tarjan_scc};
 use petgraph::unionfind::UnionFind;
 use rayon::prelude::*;
-use std::collections::HashMap;
-use std::fs::*;
-use std::io::Write;
-use std::io::{self, BufRead, BufReader};
-use std::process;
+
 // Name of the program, to be used in diagnostic messages.
 static PROGRAM_NAME: &str = "terminus";
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,33 +1,35 @@
-use byteorder::{ByteOrder, LittleEndian};
-use flate2::read::GzDecoder;
-use flate2::write::GzEncoder;
-use flate2::Compression;
-use itertools::Itertools;
-use ndarray::prelude::*;
-use petgraph as pg;
-use refinery::Partition;
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+use std::convert::TryInto;
+use std::f64;
 use std::fs::*;
 use std::io::prelude::*;
 use std::io::{self, BufReader, BufWriter};
 use std::time::Instant;
 //use std::num::pow::pow;
-//use rgsl::statistics::correlation;
-
-use std::f64;
 //use std::collections::BinaryHeap;
-use crate::petgraph::visit::EdgeRef;
-use crate::salmon_types::{EdgeInfo, EqClassExperiment, FileList, MetaInfo, TxpRecord};
+
 use binary_heap_plus::*;
+use byteorder::{ByteOrder, LittleEndian};
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use itertools::Itertools;
+use nalgebra as na;
+use ndarray::prelude::*;
 use num_traits::cast::ToPrimitive;
 use ordered_float::*;
+use petgraph as pg;
 use petgraph::unionfind::UnionFind;
+use petgraph::visit::EdgeRef;
 use rand::distributions::{Distribution, Uniform};
-//use rand::thread_rng;
 use rand_core::SeedableRng;
 use rand_pcg::Pcg64;
-use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
-use std::convert::TryInto;
+use refinery::Partition;
+//use rand::thread_rng;
+//use rgsl::statistics::correlation;
+
+use crate::salmon_types::{EdgeInfo, EqClassExperiment, FileList, MetaInfo, TxpRecord};
 
 // General functions to r/w files
 // files to be handled


### PR DESCRIPTION
- Fix a typo and link in README
- Add 2018 edition to Cargo, and fix authors list
- Remove `extern crate` (not needed with 2018 edition)
- Reorganize imports (`std`, external crates, local imports is the recommended order)